### PR TITLE
Update visitor.md & add hexo-theme-stun

### DIFF
--- a/source/hexo.md
+++ b/source/hexo.md
@@ -5,6 +5,9 @@ title: 在Hexo 中使用
 
 当然，我们也欢迎更多开发者自主的提交PR 😄
 
+## hexo-theme-stun
+> [Supported](https://github.com/liuyib/hexo-theme-stun/commit/170fcb38f939851971fc756f03ffd8f01f7a49a3) `latest`
+
 ## hexo-theme-apolloZ
 > [Supported](https://github.com/ChungZH/hexo-theme-apolloZ) `latest`
 

--- a/source/visitor.md
+++ b/source/visitor.md
@@ -15,16 +15,16 @@ new Valine({
 > 如果开启了`阅读量统计`，Valine 会`自动检测` leancloud 应用中是否存在`Counter`类，如果不存在`会自动创建`，**无需手动创建**~
 
 
-Valine会自动查找页面中`class`值为`leancloud-visitors`的元素，获取其`id`为查询条件。并将得到的值填充到其`class`的值为`leancloud-visitors-count`的子元素里：
+Valine会自动查找页面中`class`值为`leancloud_visitors`的元素，获取其`id`为查询条件。并将得到的值填充到其`class`的值为`leancloud-visitors-count`的子元素里：
 
 ``` html
 <!-- id 将作为查询条件 -->
-<span id="<Your/Path/Name>" class="leancloud-visitors" data-flag-title="Your Article Title">
+<span id="<Your/Path/Name>" class="leancloud_visitors" data-flag-title="Your Article Title">
     <em class="post-meta-item-text">阅读量 </em>
     <i class="leancloud-visitors-count">1000000</i>
 </span>
 ```
-<span id="/visitor.html" class="leancloud-visitors" data-flag-title="文章阅读量统计">
+<span id="/visitor.html" class="leancloud_visitors" data-flag-title="文章阅读量统计">
     <em class="post-meta-item-text"> 当前页访问次数 </em>
     <i class="leancloud-visitors-count">0</i>
 </span>


### PR DESCRIPTION
使用 Valine 设置阅读量统计时，在单独的文章中显示正常，在文章列表中，显示始终为零。找了两天的 bug，看了 hexo-theme-next 主题的源码才找到问题，原来 Valine 需要的类名是 `leancloud_visitors` 而不是文档中写的 `leancloud-visitors`。问题总算解决了。😄